### PR TITLE
Add GraphQL users CRUD with MySQL

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "next": "15.5.0",
     "next-auth": "^4.24.11",
     "next-pwa": "^5.6.0",
+    "graphql": "^16.9.0",
+    "graphql-yoga": "^5.3.1",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-leaflet": "^5.0.0",

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,0 +1,72 @@
+scalar DateTime
+
+enum Fungsi {
+  Intel
+  Sabhara
+  Lantas
+  Humas
+  Ops
+  Admin
+}
+
+type User {
+  id: ID!
+  nrp: String!
+  nama: String!
+  jabatan: String!
+  fungsi: Fungsi!
+  polsek: String
+  phone: String
+  email: String
+  is_active: Boolean!
+  created_at: DateTime!
+  updated_at: DateTime!
+}
+
+input CreateUserInput {
+  nrp: String!
+  nama: String!
+  jabatan: String!
+  fungsi: Fungsi!
+  polsek: String
+  phone: String
+  email: String
+  password: String!
+  is_active: Boolean
+}
+
+input UpdateUserInput {
+  nama: String
+  jabatan: String
+  fungsi: Fungsi
+  polsek: String
+  phone: String
+  email: String
+  password: String
+  is_active: Boolean
+}
+
+input UsersFilter {
+  q: String
+  fungsi: Fungsi
+  is_active: Boolean
+}
+
+type UsersPage {
+  data: [User!]!
+  total: Int!
+  page: Int!
+  pageSize: Int!
+}
+
+type Query {
+  users(page: Int = 1, pageSize: Int = 20, filter: UsersFilter): UsersPage!
+  user(id: ID!): User
+}
+
+type Mutation {
+  createUser(input: CreateUserInput!): User!
+  updateUser(id: ID!, input: UpdateUserInput!): User!
+  deleteUser(id: ID!): Boolean!
+  toggleUserActive(id: ID!, is_active: Boolean!): User!
+}

--- a/src/app/api/graphql/route.ts
+++ b/src/app/api/graphql/route.ts
@@ -1,0 +1,15 @@
+import { createYoga, createSchema } from 'graphql-yoga';
+import type { NextRequest } from 'next/server';
+import { resolvers } from '@/graphql/resolvers';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const typeDefs = fs.readFileSync(path.join(process.cwd(), 'schema.graphql'), 'utf8');
+const schema = createSchema({ typeDefs, resolvers });
+
+const yoga = createYoga<{ req: NextRequest }>({
+  schema,
+  graphqlEndpoint: '/api/graphql',
+});
+
+export { yoga as GET, yoga as POST, yoga as OPTIONS };

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -1,0 +1,45 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { GraphQLScalarType, Kind } from 'graphql';
+import {
+  listUsers,
+  getUser,
+  createUser,
+  updateUser,
+  deleteUser,
+  toggleUserActive,
+} from '@/lib/usersRepo';
+
+const DateTimeScalar = new GraphQLScalarType({
+  name: 'DateTime',
+  serialize(value: any) {
+    return new Date(value).toISOString();
+  },
+  parseValue(value: any) {
+    return new Date(value);
+  },
+  parseLiteral(ast) {
+    if (ast.kind === Kind.STRING) {
+      return new Date(ast.value);
+    }
+    return null;
+  },
+});
+
+export const resolvers = {
+  DateTime: DateTimeScalar,
+  Query: {
+    users: async (_: unknown, args: { page?: number; pageSize?: number; filter?: any }) => {
+      const page = Math.max(1, args.page ?? 1);
+      const pageSize = Math.min(100, Math.max(1, args.pageSize ?? 20));
+      const { rows, total } = await listUsers(page, pageSize, args.filter);
+      return { data: rows, total, page, pageSize };
+    },
+    user: async (_: unknown, { id }: { id: string }) => getUser(Number(id)),
+  },
+  Mutation: {
+    createUser: async (_: unknown, { input }: any) => createUser(input),
+    updateUser: async (_: unknown, { id, input }: any) => updateUser(Number(id), input),
+    deleteUser: async (_: unknown, { id }: any) => deleteUser(Number(id)),
+    toggleUserActive: async (_: unknown, { id, is_active }: any) => toggleUserActive(Number(id), is_active),
+  },
+};

--- a/src/lib/usersRepo.ts
+++ b/src/lib/usersRepo.ts
@@ -1,0 +1,123 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { executeQuery, findOne } from './database';
+import bcrypt from 'bcryptjs';
+
+export interface UserRow {
+  id: number;
+  nrp: string;
+  nama: string;
+  jabatan: string;
+  fungsi: 'Intel' | 'Sabhara' | 'Lantas' | 'Humas' | 'Ops' | 'Admin';
+  polsek: string | null;
+  phone: string | null;
+  email: string | null;
+  is_active: number;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export async function listUsers(
+  page: number,
+  pageSize: number,
+  filter?: { q?: string; fungsi?: string; is_active?: boolean }
+) {
+  const offset = (page - 1) * pageSize;
+  const where: string[] = [];
+  const params: any[] = [];
+
+  if (filter?.q) {
+    const like = `%${filter.q}%`;
+    where.push('(nrp LIKE ? OR nama LIKE ? OR email LIKE ? OR phone LIKE ?)');
+    params.push(like, like, like, like);
+  }
+  if (filter?.fungsi) {
+    where.push('fungsi = ?');
+    params.push(filter.fungsi);
+  }
+  if (typeof filter?.is_active === 'boolean') {
+    where.push('is_active = ?');
+    params.push(filter.is_active ? 1 : 0);
+  }
+  const whereSql = where.length ? `WHERE ${where.join(' AND ')}` : '';
+
+  const totalRes = await executeQuery(
+    `SELECT COUNT(*) AS total FROM users ${whereSql}`,
+    params
+  );
+  const total = Number((totalRes.data as any)[0]?.total ?? 0);
+
+  const rowsRes = await executeQuery(
+    `SELECT id,nrp,nama,jabatan,fungsi,polsek,phone,email,is_active,created_at,updated_at
+     FROM users ${whereSql}
+     ORDER BY id DESC
+     LIMIT ? OFFSET ?`,
+    [...params, pageSize, offset]
+  );
+  const rows = (rowsRes.data as UserRow[]).map(r => ({ ...r, is_active: r.is_active ? 1 : 0 }));
+  return { rows, total };
+}
+
+export async function getUser(id: number) {
+  return findOne(`SELECT * FROM users WHERE id = ? LIMIT 1`, [id]);
+}
+
+export async function createUser(input: any) {
+  const {
+    nrp,
+    nama,
+    jabatan,
+    fungsi,
+    polsek,
+    phone,
+    email,
+    password,
+    is_active = true,
+  } = input;
+
+  const password_hash = await bcrypt.hash(password, 10);
+  const res = await executeQuery(
+    `INSERT INTO users (nrp,nama,jabatan,fungsi,polsek,phone,email,password_hash,is_active)
+     VALUES (?,?,?,?,?,?,?,?,?)`,
+    [nrp, nama, jabatan, fungsi, polsek ?? null, phone ?? null, email ?? null, password_hash, is_active ? 1 : 0]
+  );
+  return getUser((res as any).insertId);
+}
+
+export async function updateUser(id: number, input: any) {
+  const allowed = ['nama', 'jabatan', 'fungsi', 'polsek', 'phone', 'email', 'is_active'];
+  const sets: string[] = [];
+  const params: any[] = [];
+
+  for (const key of allowed) {
+    if (key in input) {
+      sets.push(`${key} = ?`);
+      params.push(
+        key === 'is_active' ? (input[key] ? 1 : 0) : input[key] ?? null
+      );
+    }
+  }
+  if (input.password) {
+    sets.push('password_hash = ?');
+    params.push(await bcrypt.hash(input.password, 10));
+  }
+  if (!sets.length) return getUser(id);
+
+  await executeQuery(
+    `UPDATE users SET ${sets.join(', ')}, updated_at = CURRENT_TIMESTAMP WHERE id = ?`,
+    [...params, id]
+  );
+  return getUser(id);
+}
+
+export async function deleteUser(id: number) {
+  const res = await executeQuery(`DELETE FROM users WHERE id = ?`, [id]);
+  return (res as any).affectedRows > 0;
+}
+
+export async function toggleUserActive(id: number, is_active: boolean) {
+  await executeQuery(
+    `UPDATE users SET is_active = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`,
+    [is_active ? 1 : 0, id]
+  );
+  return getUser(id);
+}


### PR DESCRIPTION
## Summary
- add GraphQL schema and resolvers for user CRUD
- connect MySQL repository for users
- expose Yoga-based GraphQL endpoint

## Testing
- `npm run lint` (fails: A `require()` style import is forbidden, Unexpected any)
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68ab5050254c832fb193b480eb26c272